### PR TITLE
refactor(app): change error messages

### DIFF
--- a/internal/service/file.go
+++ b/internal/service/file.go
@@ -11,7 +11,7 @@ import (
 func (s service) ExtractAndMoveConfigDirectory(repositoryPath string) error {
 	configPath, err := getConfigPath(repositoryPath)
 	if err != nil {
-		return fmt.Errorf("failed to config path: %w", err)
+		return fmt.Errorf("get config path: %w", err)
 	}
 
 	err = moveConfigDirectory(configPath)
@@ -20,7 +20,7 @@ func (s service) ExtractAndMoveConfigDirectory(repositoryPath string) error {
 			return err
 		}
 
-		return fmt.Errorf("failed to move config directory: %w", err)
+		return fmt.Errorf("move config directory: %w", err)
 	}
 
 	return nil
@@ -37,17 +37,17 @@ func moveConfigDirectory(configPath string) error {
 
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return fmt.Errorf("failed to get path to the home directory: %w", err)
+		return fmt.Errorf("get home directory: %w", err)
 	}
 
 	err = os.Rename(configPath, fmt.Sprintf("%s/.config/nvim", homeDir))
 	if err != nil {
 		removeErr := os.RemoveAll(configPath)
 		if removeErr != nil {
-			return fmt.Errorf("moving config failed, failed to remove repository: %w", err)
+			return fmt.Errorf("moving config failed, can't remove old config path: %w", err)
 		}
 
-		return fmt.Errorf("failed to move repository into .config directory: %w", err)
+		return fmt.Errorf("can't move repository into .config directory: %w", err)
 	}
 
 	return nil
@@ -60,7 +60,7 @@ func getConfigPath(repositoryPath string) (string, error) {
 
 	err := filepath.Walk(repositoryPath, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
-			return fmt.Errorf("walk in repository error: %w", err)
+			return fmt.Errorf("walk through files in directory: %w", err)
 		}
 
 		if filesCount > 0 && info.Name() == "nvim" && info.IsDir() {
@@ -68,6 +68,7 @@ func getConfigPath(repositoryPath string) (string, error) {
 
 			return nil
 		}
+
 		filesCount++
 
 		return nil

--- a/internal/service/managers.go
+++ b/internal/service/managers.go
@@ -18,14 +18,14 @@ func (s service) ProcessPackageManagers(stdin io.Reader) (string, error) {
 	case PackerPluginManager:
 		err = installPacker()
 		if err != nil {
-			return "", fmt.Errorf("install packer error: %w", err)
+			return "", fmt.Errorf("install packer: %w", err)
 		}
 
 		return PackerPluginManager, nil
 	case VimPlugPluginManager:
 		err = installVimPlug()
 		if err != nil {
-			return "", fmt.Errorf("install vim-plug error: %w", err)
+			return "", fmt.Errorf("install vim-plug: %w", err)
 		}
 
 		return VimPlugPluginManager, nil
@@ -42,7 +42,7 @@ func (s service) GetPackageMangerIfNotInstalled(stdin io.Reader) (string, error)
 	reader := bufio.NewReader(stdin)
 	haveInstalledPackageManagers, err := s.input.GetInput(reader)
 	if err != nil {
-		return "", fmt.Errorf("failed to get user input: %w", err)
+		return "", fmt.Errorf("get input for is user has installed pkg manager: %w", err)
 	}
 
 	switch haveInstalledPackageManagers {
@@ -60,7 +60,7 @@ func (s service) GetPackageMangerIfNotInstalled(stdin io.Reader) (string, error)
 func installVimPlug() error {
 	file, err := os.Create("vim-plug.sh")
 	if err != nil {
-		return fmt.Errorf("create sh file for install script error: %w", err)
+		return fmt.Errorf("create file for installing script: %w", err)
 	}
 
 	_, err = file.Write([]byte(
@@ -71,17 +71,17 @@ func installVimPlug() error {
     `,
 	))
 	if err != nil {
-		return fmt.Errorf("write to sh file error: %w", err)
+		return fmt.Errorf("write data to installing script file: %w", err)
 	}
 
 	cmd := exec.Command("/bin/sh", "vim-plug.sh")
 	if err = cmd.Run(); err != nil {
-		return fmt.Errorf("run sh file error: %w", err)
+		return fmt.Errorf("execute script for vim plug installation: %w", err)
 	}
 
 	err = os.Remove("./vim-plug.sh")
 	if err != nil {
-		return fmt.Errorf("remove sh file error: %w", err)
+		return fmt.Errorf("remove installation script file: %w", err)
 	}
 
 	return nil
@@ -90,7 +90,7 @@ func installVimPlug() error {
 func installPacker() error {
 	file, err := os.Create("packer.sh")
 	if err != nil {
-		return fmt.Errorf("create file for install script error: %w", err)
+		return fmt.Errorf("create file for installing script: %w", err)
 	}
 
 	_, err = file.Write([]byte(
@@ -101,17 +101,17 @@ func installPacker() error {
     `,
 	))
 	if err != nil {
-		return fmt.Errorf("write to sh file error: %w", err)
+		return fmt.Errorf("write data to installing script file: %w", err)
 	}
 
 	cmd := exec.Command("/bin/sh", "packer.sh")
 	if err = cmd.Run(); err != nil {
-		return fmt.Errorf("run sh file error: %w", err)
+		return fmt.Errorf("execute script for vim plug installation: %w", err)
 	}
 
 	err = os.Remove("./packer.sh")
 	if err != nil {
-		return fmt.Errorf("remove sh file error: %w", err)
+		return fmt.Errorf("remove installation script file: %w", err)
 	}
 
 	return nil

--- a/internal/service/repository.go
+++ b/internal/service/repository.go
@@ -51,21 +51,21 @@ func haveSSHURLParts(url string) bool {
 func createPublicSSHKeysFromFile(input input.Inputter, stdin io.Reader) (*ssh.PublicKeys, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get home directory: %w", err)
+		return nil, fmt.Errorf("get home directory: %w", err)
 	}
 
 	fmt.Print("Enter path to your ssh file(.ssh/id_ed3122): ")
 
 	keyPath, err := input.GetInput(stdin)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get user input: %w", err)
+		return nil, fmt.Errorf("get input for ssh key path: %w", err)
 	}
 
 	filePath := fmt.Sprintf("%s/%s", homeDir, keyPath)
 
 	publicKeys, err := ssh.NewPublicKeysFromFile("git", filePath, "")
 	if err != nil {
-		return nil, fmt.Errorf("failed to create ssh public keys from file: %w", err)
+		return nil, fmt.Errorf("create ssh public from file: %w", err)
 	}
 
 	return publicKeys, nil

--- a/internal/service/url.go
+++ b/internal/service/url.go
@@ -10,12 +10,12 @@ func (s service) ProcessUserURL(stdin io.Reader) (string, error) {
 
 	configURL, err := s.input.GetInput(stdin)
 	if err != nil {
-		return "", fmt.Errorf("failed get user input: %w", err)
+		return "", fmt.Errorf("get input for config url: %w", err)
 	}
 
 	err = s.validator.ValidateURL(configURL)
 	if err != nil {
-		return "", fmt.Errorf("URL validation failed: %w", err)
+		return "", err
 	}
 
 	return configURL, nil

--- a/internal/service/url_test.go
+++ b/internal/service/url_test.go
@@ -41,7 +41,7 @@ func Test_ProcesUserURL(t *testing.T) {
 			name:        "ProcessUserURL fail with invalid host",
 			input:       "test",
 			expectedURL: "",
-			expectedErr: fmt.Errorf("URL validation failed: %w", validation.ErrURLContainsInvalidHost),
+			expectedErr: validation.ErrURLContainsInvalidHost,
 		},
 	}
 

--- a/pkg/input/input.go
+++ b/pkg/input/input.go
@@ -20,7 +20,7 @@ func (i input) GetInput(stdin io.Reader) (string, error) {
 
 	data, err := reader.ReadString('\n')
 	if err != nil {
-		return "", fmt.Errorf("get input error: %w", err)
+		return "", fmt.Errorf("read string from reader: %w", err)
 	}
 
 	return strings.ReplaceAll(data, "\n", ""), nil

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -55,7 +55,7 @@ func (v validation) ValidateRepoFiles(path string) error {
 			return err
 		}
 
-		return fmt.Errorf("failed to get list of repository files: %w", err)
+		return fmt.Errorf("get list of repository files: %w", err)
 	}
 
 	baseFiles := [2]string{"init.lua", "init.vim"}
@@ -84,7 +84,7 @@ func getRepositoryFiles(path string) (string, error) {
 
 	err = filepath.Walk(path, func(_ string, info fs.FileInfo, err error) error {
 		if err != nil {
-			return fmt.Errorf("walk in repository error: %w", err)
+			return fmt.Errorf("walk through files in directory: %w", err)
 		}
 
 		files += fmt.Sprintf(" %s", info.Name())
@@ -92,7 +92,7 @@ func getRepositoryFiles(path string) (string, error) {
 		return nil
 	})
 	if err != nil {
-		return "", fmt.Errorf("get list of files error: %w", err)
+		return "", fmt.Errorf("get list of repository files: %w", err)
 	}
 
 	return files, nil


### PR DESCRIPTION
In this PR I changed error messages by removing `error` phrase in every error message to avoid duplication

[Resourse](https://docs.gitlab.com/ee/development/go_guide/#adding-context)

>Don’t use words like failed, error, didn't. As it’s an error, the user already knows that something failed and this might lead to having strings like failed xx failed xx failed xx. Explain what failed instead.

